### PR TITLE
fix limit parameter for getchatmessages

### DIFF
--- a/nodes/GOWA/chat.operations.ts
+++ b/nodes/GOWA/chat.operations.ts
@@ -50,7 +50,7 @@ export const chatProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['chat'],
-				operation: ['listChats'],
+				operation: ['listChats', 'getChatMessages'],
 			},
 		},
 		typeOptions: {


### PR DESCRIPTION
fix this error, the "limit" parameter is not exists on 'getChatMessages' node
<img width="1397" height="839" alt="image" src="https://github.com/user-attachments/assets/569962d9-d012-402b-9172-a59da473b215" />
